### PR TITLE
feat: add Docker deployment support for TSBot

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.gitignore
+**/__pycache__
+**/.pytest_cache
+**/.mypy_cache
+**/*.pyc
+backend/.venv
+web/node_modules
+voice-service/target
+logs
+data
+*.db
+*.log

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,0 +1,16 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+COPY backend/requirements.txt /app/backend/requirements.txt
+RUN pip install --no-cache-dir -r /app/backend/requirements.txt
+
+COPY backend /app/backend
+COPY proto /app/proto
+
+EXPOSE 8009
+
+CMD ["python", "-m", "uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8009"]

--- a/Dockerfile.voice-service
+++ b/Dockerfile.voice-service
@@ -1,0 +1,23 @@
+FROM rust:1.78-bookworm AS builder
+
+WORKDIR /app
+
+COPY voice-service /app/voice-service
+COPY proto /app/proto
+COPY vendor /app/vendor
+
+RUN cargo build --manifest-path /app/voice-service/Cargo.toml --release
+
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=builder /app/voice-service/target/release/voice-service /usr/local/bin/voice-service
+
+EXPOSE 50051
+
+CMD ["voice-service", "0.0.0.0:50051"]

--- a/Dockerfile.voice-service
+++ b/Dockerfile.voice-service
@@ -1,6 +1,10 @@
-FROM rust:1.78-bookworm AS builder
+FROM rust:1.88-bookworm AS builder
 
 WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends cmake \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY voice-service /app/voice-service
 COPY proto /app/proto

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,0 +1,12 @@
+FROM node:20-bookworm-slim
+
+WORKDIR /app/web
+
+COPY web/package*.json /app/web/
+RUN npm install
+
+COPY web /app/web
+
+EXPOSE 5173
+
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5173"]

--- a/HOWTOSTART.md
+++ b/HOWTOSTART.md
@@ -194,6 +194,48 @@ npm.cmd --prefix web install
 - `TSBOT_FFMPEG`
 
 如果暂时没有这些工具，后端和前端仍然可以正常启动，但播放控制相关接口会因为 gRPC 语音服务未启动而不可用。
+## Docker 运行
+
+项目根目录已提供：
+
+- `docker-compose.yml`
+- `Dockerfile.backend`
+- `Dockerfile.voice-service`
+- `Dockerfile.web`
+
+### 1. 准备配置
+
+```bash
+cp tsbot.env.example tsbot.env
+```
+
+> 如果 `NeteaseCloudMusicApi` 跑在宿主机，请将 `TSBOT_NETEASE_API_BASE` 配置为 `http://host.docker.internal:3000/`。
+
+### 2. 构建并启动
+
+```bash
+docker compose up -d --build
+```
+
+### 3. 查看运行状态
+
+```bash
+docker compose ps
+docker compose logs -f
+```
+
+### 4. 停止并清理容器
+
+```bash
+docker compose down
+```
+
+默认端口映射：
+
+- `50051:50051`（voice-service gRPC）
+- `8009:8009`（backend）
+- `5173:5173`（web）
+
 ## 环境变量配置
 
 编辑 `tsbot.env` 文件：

--- a/README.en.md
+++ b/README.en.md
@@ -205,6 +205,44 @@ Run in 3 terminals:
 ./run-web.sh
 ```
 
+## Docker Deployment
+
+The repository now includes:
+
+- `docker-compose.yml`
+- `Dockerfile.backend`
+- `Dockerfile.voice-service`
+- `Dockerfile.web`
+
+### 1) Prepare env file
+
+```bash
+cp tsbot.env.example tsbot.env
+```
+
+If your `NeteaseCloudMusicApi` runs on the host machine, set:
+
+- `TSBOT_NETEASE_API_BASE=http://host.docker.internal:3000/`
+
+### 2) Build and run
+
+```bash
+docker compose up -d --build
+```
+
+### 3) Inspect
+
+```bash
+docker compose ps
+docker compose logs -f backend
+```
+
+### 4) Stop
+
+```bash
+docker compose down
+```
+
 ## Default Ports
 
 - **voice-service gRPC**: `127.0.0.1:50051`

--- a/README.md
+++ b/README.md
@@ -205,6 +205,45 @@ chmod +x ./nohup-start.sh ./nohup-stop.sh ./nohup-status.sh
 ./run-web.sh
 ```
 
+## Docker 部署（新增）
+
+### 1) 准备环境变量
+
+```bash
+cp tsbot.env.example tsbot.env
+```
+
+至少确认以下配置：
+
+- `TSBOT_TS3_HOST` / `TSBOT_TS3_PORT` / `TSBOT_TS3_CHANNEL_ID`
+- `TSBOT_COOKIE_KEY`
+- `TSBOT_NETEASE_API_BASE`（如果你在宿主机跑 NeteaseCloudMusicApi，可设为 `http://host.docker.internal:3000/`）
+
+### 2) 构建并启动
+
+```bash
+docker compose up -d --build
+```
+
+### 3) 查看状态与日志
+
+```bash
+docker compose ps
+docker compose logs -f backend
+```
+
+### 4) 停止
+
+```bash
+docker compose down
+```
+
+Compose 默认会启动 3 个服务：
+
+- `voice-service`（50051）
+- `backend`（8009）
+- `web`（5173）
+
 ## 默认端口
 
 - **voice-service gRPC**: `127.0.0.1:50051`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+services:
+  voice-service:
+    build:
+      context: .
+      dockerfile: Dockerfile.voice-service
+    env_file:
+      - tsbot.env
+    ports:
+      - "50051:50051"
+    volumes:
+      - ./logs:/app/logs
+
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile.backend
+    env_file:
+      - tsbot.env
+    environment:
+      TSBOT_HOST: 0.0.0.0
+      TSBOT_PORT: 8009
+      TSBOT_VOICE_GRPC_ADDR: voice-service:50051
+      DATABASE_URL: sqlite:///./data/tsbot.db
+    depends_on:
+      - voice-service
+    ports:
+      - "8009:8009"
+    volumes:
+      - ./logs:/app/logs
+      - ./data:/app/data
+
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile.web
+    env_file:
+      - tsbot.env
+    environment:
+      VITE_DEV_HOST: 0.0.0.0
+      VITE_DEV_PORT: 5173
+      VITE_API_BASE: http://127.0.0.1:8009
+    depends_on:
+      - backend
+    ports:
+      - "5173:5173"


### PR DESCRIPTION
### Motivation

- Provide an easy, containerized way to run the three core components (`voice-service`, `backend`, `web`) so users can deploy the stack without installing all native toolchains on the host. 
- Reduce friction for development/CI by standardizing service boundaries and network settings in `docker-compose.yml`. 
- Offer documented guidance for running the project in containers and for connecting external services like `NeteaseCloudMusicApi` from host or other containers.

### Description

- Add `Dockerfile.voice-service` that performs a Rust multi-stage build and produces a release binary, and installs `ffmpeg` and certificates in the runtime image to allow audio processing. 
- Add `Dockerfile.backend` using `python:3.11-slim` that installs Python dependencies and runs the FastAPI app with `uvicorn` on `0.0.0.0:8009`. 
- Add `Dockerfile.web` using `node:20` that installs frontend dependencies and runs the Vite dev server on `0.0.0.0:5173`. 
- Add `docker-compose.yml` to run the three services with `tsbot.env` injection, service dependency ordering, ports mapping, persistent SQLite path via `DATABASE_URL=sqlite:///./data/tsbot.db`, and host-visible ports for `50051`, `8009`, and `5173`. 
- Add `.dockerignore` to reduce build context by excluding `.git`, `node_modules`, `voice-service/target`, logs, local DB files, and virtualenvs. 
- Update documentation (`README.md`, `README.en.md`, `HOWTOSTART.md`) with a short Docker workflow (prepare `tsbot.env`, `docker compose up -d --build`, inspect logs, `docker compose down`) and a note about using `host.docker.internal` for a host-run `NeteaseCloudMusicApi`.

### Testing

- Attempted to validate the compose file with `docker compose config` but the Docker CLI is not available in the current environment, so container-level validation and builds could not be executed (test failed due to `docker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af0e299fec832295fda7533cfc7ba7)