### PR TITLE
修复了几个小问题

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -11,6 +11,12 @@ RUN pip install --no-cache-dir -r /app/backend/requirements.txt
 COPY backend /app/backend
 COPY proto /app/proto
 
+#安装chromium
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+RUN python -m playwright install --with-deps chromium && rm -rf /var/lib/apt/lists/*
+
 EXPOSE 8009
 
 CMD ["python", "-m", "uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8009"]

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -8,7 +8,7 @@ RUN npm ci
 COPY web /app/web
 RUN npm run build
 
-FROM nginx:1.27-alpine
+FROM nginx:1.30.2-alpine
 
 COPY docker/nginx-web.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/web/dist /usr/share/nginx/html

--- a/backend/main.py
+++ b/backend/main.py
@@ -3871,6 +3871,17 @@ async def admin_qr_check(key: str, request: Request, session: Session = Depends(
     code = (data or {}).get("code")
     cookie = (data or {}).get("cookie") or ""
     if code == 803 and cookie:
+        target_keys = {
+            "music_r_t", "music_a_t", "music_r_u", 
+            "music_sns", "nmtid", "__csrf", "music_u"
+        }
+        pairs = re.findall(r"([^;\s=]+)\s*=\s*([^;]*)", cookie)
+        result = {}
+        for key, value in pairs:
+            k_stripped = key.strip()
+            if k_stripped.lower() in target_keys:
+                result[k_stripped] = value.strip()
+        cookie = "; ".join(f"{k}={v}" for k, v in result.items())
         _set_secret(session, "netease_cookie", cookie)
         return {"code": code, "message": "authorized", "admin_cookie_set": True}
     if code == 800:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - "50051:50051"
     volumes:
       - ./logs:/app/logs
+      - voicetmp:/app/tmp
 
   backend:
     build:
@@ -28,6 +29,7 @@ services:
     volumes:
       - ./logs:/app/logs
       - ./data:/app/data
+      - voicetmp:/app/tmp
 
   web:
     build:
@@ -37,3 +39,6 @@ services:
       - backend
     ports:
       - "8080:8080"
+
+volumes:
+  voicetmp:

--- a/web/index.html
+++ b/web/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="referrer" content="no-referrer" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>TSBot Music</title>
   </head>


### PR DESCRIPTION
### 修复详情

#### 前端B站资源加载
- 修复 B 站视频图片 403 问题：在index.html中添加`<meta name="referrer" content="no-referrer" />`,阻止vue请求时携带本地URL作为`Referer`头,解决 B 站防盗链校验导致的资源加载失败

#### 后端网易云登录接口
- 修复网易云登录接口 Cookie 解析错误：原逻辑将neteaseapi接口返回的cookie键的值作为cookie处理,但该接口返回的值为`Set-Cookie`响应头格式；现已改为通过正则从`Set-Cookie`中提取cookie

#### Docker环境b站视频播放
- 修复Docker环境下voice-service无法播放B站视频问题：原`docker-compose`配置未将voice-service与backend的`/app/tmp`路径进行共享；现补充 volume 挂载配置，确保临时文件可被voice-service正常读取